### PR TITLE
Fix hanging constructor

### DIFF
--- a/iterator_test.go
+++ b/iterator_test.go
@@ -50,22 +50,22 @@ func TestIterator(t *testing.T) {
 			lower, upper []byte
 		}
 		cases := []testCase{
-			{nil, []byte{0}},
-			{[]byte{1}, []byte{2}},
-			{[]byte{3, 0}, []byte{4, 2, 0}},
-			{[]byte{5, 6, 9}, []byte{7}},
-			{[]byte{8}, []byte{8}},
-			{[]byte{8}, []byte{7}},
+			{nil, []byte{0, 0}},
+			{[]byte{1, 0}, []byte{2, 0}},
+			{[]byte{3, 5}, []byte{4, 2, 0}},
+			{[]byte{5, 6, 9, 0}, []byte{7, 0}},
+			{[]byte{8, 0}, []byte{8, 0}},
+			{[]byte{8, 0}, []byte{7, 0}},
 		}
 
 		runCase := func(t *testing.T, tc testCase) {
-			it := iter.NewPrefixBoundIterator(tree, tc.lower, tc.upper)
+			it := iter.NewPrefixBoundIterator(tree.NodeIterator(iter.HexToKeyBytes(tc.lower)), tc.upper)
 			for it.Next(true) {
 				if bytes.Compare(it.Path(), tc.lower) < 0 {
 					t.Fatalf("iterator outside lower bound: %v", it.Path())
 				}
-				if bytes.Compare(tc.upper, it.Path()) <= 0 {
-					t.Fatalf("iterator outside upper bound: %v", it.Path())
+				if bytes.Compare(tc.upper, it.Path()) < 0 {
+					t.Fatalf("iterator outside upper bound: %v <= %v", tc.upper, it.Path())
 				}
 			}
 		}
@@ -86,6 +86,10 @@ func TestIterator(t *testing.T) {
 						t.Fatalf("wrong path value\nexpected:\t%v\nactual:\t\t%v",
 							allPaths[ix], it.Path())
 					}
+				}
+				// if the last node path was even-length, it will be duplicated
+				if len(allPaths[ix-1])&0b1 == 0 {
+					ix--
 				}
 			}
 		}


### PR DESCRIPTION
Fixes unacceptably slow iterator constructor:

This constructor gave a "correct" iterator which covers exactly the bounded range `[lower, upper)` but did so via an O(n) seek to the desired position. This was too slow, so this reverts the constructor to one which simply accepts a `NodeIterator` object and an upper bound, at the cost of being unable to seek to an odd-length path (i.e. the bounds cannot specify a granularity of less than a full byte, so if the boundary ends in a single nibble, duplicate nodes could be iterated).